### PR TITLE
Feature/47/gc log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ add_library(standart_set
 
     src/ControlGraph.cpp
     src/ControlGraphVisualizer.cpp
+    src/Timer.cpp
+    src/GCLogger.cpp
 )
 
 if (USE_LLVM)

--- a/include/Timer.h
+++ b/include/Timer.h
@@ -1,0 +1,118 @@
+
+#ifndef LLST_TIMER_H_INCLUDED
+#define LLST_TIMER_H_INCLUDED
+
+#include <string>
+#include <sstream>
+#include <math.h> 
+using std::stringstream;
+#include <time.h>
+#include <iomanip>
+
+#if defined(unix) || defined(__unix__) || defined(__unix)
+    #include <sys/time.h>
+    typedef timeval systemTimeValue;
+#else
+    typedef clock_t systemTimeValue;
+#endif
+
+
+    
+//analogue of c++11 ratio from chrono.h
+template <int NUM, int DEN>
+struct TRatio
+{
+    static const int num = NUM;
+    static const int den = DEN;
+};
+
+typedef TRatio<86400,1>      TDay;
+typedef TRatio<3600,1>       THour;
+typedef TRatio<60,1>         TMin;
+typedef TRatio<1,1>          TSec;
+typedef TRatio<1,1000>       TMillisec;
+typedef TRatio<1,1000000>    TMicrosec;
+typedef TRatio<1,1000000000> TNanosec;
+
+
+//type used to show string representation of ratio
+enum SuffixMode {SNONE, SSHORT, SFULL};
+
+//analogue of c++11 duration
+template <typename RATIO>
+class TDuration {
+private:
+    double value;
+public:
+    //argument: duration in target ratio value
+    TDuration(double duration){
+        value = duration;
+    }
+    
+    TDuration() {value = 0;}
+    
+    bool isEmpty() { return value == 0;}
+    
+    template <typename RATIO2> TDuration<RATIO2> convertTo(){
+        return TDuration<RATIO2>(value * (RATIO::num * RATIO2::den) / (double)(RATIO::den * RATIO2::num));
+    }
+    int toInt(){
+        return floor(value);
+    }
+    double toDouble(){
+        return value;
+    }
+    std::string toString(SuffixMode sMode = SNONE, int symbolsAfterPoint = 0,
+                                      const char* pointSymbol = ".", const char* spaceSymbol = " "){
+        stringstream ss; 
+        ss << floor(value);
+        if(symbolsAfterPoint)
+            ss << pointSymbol << std::setfill('0') << std::setw(symbolsAfterPoint) 
+               << floor((value - floor(value)) * pow(10.0, symbolsAfterPoint));
+        if(sMode != SNONE)
+            ss << spaceSymbol << getSuffix(sMode);
+        return ss.str();
+    }
+    std::string getSuffix(SuffixMode sMode);
+    
+    std::ostream& operator<<(std::ostream& os){
+        os << toString();
+        return os;
+    }
+
+    bool operator< (const TDuration<RATIO>& rhs){
+        return value < rhs.value;
+    }
+
+    TDuration<RATIO> operator+(const TDuration<RATIO>& rhs){
+        return TDuration<RATIO>(value + rhs.value);
+    }
+
+    TDuration<RATIO> operator-(const TDuration<RATIO>& rhs){
+        return TDuration<RATIO>(value - rhs.value);
+    }
+
+    bool operator> (const TDuration<RATIO>& rhs){return  !(operator< (rhs));}
+
+    friend class Timer;
+};
+
+
+class Timer {
+private:
+    systemTimeValue timeCreate; 
+    double getDiffSec();
+public:
+    //timer which count time from specified unix-time.
+    Timer(time_t time);
+    //default constructor is implicit Timer::now()
+    Timer(){ this->start();}
+    static Timer now() {Timer t; return t;}
+    void start();
+    template <typename RATIO>
+    TDuration<RATIO> get(){
+        return TDuration<TSec>(getDiffSec()).convertTo<RATIO>();
+    }
+};
+
+#endif

--- a/include/args.h
+++ b/include/args.h
@@ -43,10 +43,11 @@ struct args
     std::size_t heapSize;
     std::size_t maxHeapSize;
     std::string imagePath;
+    std::string memoryManagerType;
     int         showHelp;
     int         showVersion;
     args() :
-        heapSize(0), maxHeapSize(0), showHelp(false), showVersion(false)
+        heapSize(0), maxHeapSize(0), memoryManagerType(), showHelp(false), showVersion(false)
     {
     }
     void parse(int argc, char **argv);

--- a/src/BakerMemoryManager.cpp
+++ b/src/BakerMemoryManager.cpp
@@ -46,14 +46,11 @@ bool is_aligned_properly(uint32_t x) {
 }
 
 BakerMemoryManager::BakerMemoryManager() :
-    m_collectionsCount(0), m_allocationsCount(0), m_totalCollectionDelay(0),
-    m_heapSize(0), m_maxHeapSize(0), m_heapOne(0), m_heapTwo(0),
+    m_memoryInfo(), m_heapSize(0), m_maxHeapSize(0), m_heapOne(0), m_heapTwo(0),
     m_activeHeapOne(true), m_inactiveHeapBase(0), m_inactiveHeapPointer(0),
     m_activeHeapBase(0), m_activeHeapPointer(0), m_staticHeapSize(0),
     m_staticHeapBase(0), m_staticHeapPointer(0), m_externalPointersHead(0)
-{
-    // Nothing to be done here
-}
+{}
 
 BakerMemoryManager::~BakerMemoryManager()
 {
@@ -198,7 +195,7 @@ void* BakerMemoryManager::allocate(std::size_t requestedSize, bool* gcOccured /*
         assert( is_aligned_properly(result) );
 
         if (gcOccured && !*gcOccured)
-            m_allocationsCount++;
+            m_memoryInfo.allocationsCount++;
         return result;
     }
 
@@ -379,10 +376,15 @@ BakerMemoryManager::TMovableObject* BakerMemoryManager::moveObject(TMovableObjec
     }
 }
 
+
 void BakerMemoryManager::collectGarbage()
 {
-    m_collectionsCount++;
-
+    //get statistic before collect
+    m_memoryInfo.collectionsCount++;
+    TMemoryManagerEvent event("GC");
+    event.begin = m_memoryInfo.timer.get<TSec>();
+    event.heapInfo.usedHeapSizeBeforeCollect =  (m_heapSize/2 - (m_activeHeapPointer - m_activeHeapBase));
+    event.heapInfo.totalHeapSize = m_heapSize;
     // First of all swapping the spaces
     if (m_activeHeapOne)
     {
@@ -402,21 +404,18 @@ void BakerMemoryManager::collectGarbage()
     // objects down the hierarchy to find active objects.
     // Then moving them to the new active heap.
 
-    // Storing timestamp on start
-    timeval tv1;
-    gettimeofday(&tv1, NULL);
-
     // Moving the live objects in the new heap
     moveObjects();
 
-    // Storing timestamp of the end
-    timeval tv2;
-    gettimeofday(&tv2, NULL);
 
     std::memset(m_inactiveHeapBase, 0, m_heapSize / 2);
 
     // Calculating total microseconds spent in the garbage collection procedure
-    m_totalCollectionDelay += (tv2.tv_sec - tv1.tv_sec) * 1000000 + (tv2.tv_usec - tv1.tv_usec);
+    event.heapInfo.usedHeapSizeAfterCollect =  (m_heapSize/2 - (m_activeHeapPointer - m_activeHeapBase));
+    event.timeDiff = m_memoryInfo.timer.get<TSec>() - event.begin;
+    m_memoryInfo.totalCollectionDelay += event.timeDiff.convertTo<TMicrosec>().toInt();
+    m_memoryInfo.events.push_front(event);
+    m_gcLogger->writeLogLine(event);
 }
 
 void BakerMemoryManager::moveObjects()
@@ -529,11 +528,6 @@ void BakerMemoryManager::releaseExternalHeapPointer(object_ptr& pointer) {
 
 TMemoryManagerInfo BakerMemoryManager::getStat()
 {
-    TMemoryManagerInfo info;
-    std::memset(&info, 0, sizeof(info));
-
-    info.allocationsCount     = m_allocationsCount;
-    info.collectionsCount     = m_collectionsCount;
-    info.totalCollectionDelay = m_totalCollectionDelay;
-    return info;
+    return m_memoryInfo;
 }
+

--- a/src/GCLogger.cpp
+++ b/src/GCLogger.cpp
@@ -1,0 +1,39 @@
+#include "memory.h"
+
+
+GCLogger::GCLogger(const char* fileName):
+	m_logFile(fileName, std::fstream::out)
+{}
+
+GCLogger::~GCLogger(){
+    m_logFile.flush();
+}
+
+enum MeasuringConstants { bytes_in_kb = 1024 };
+
+
+void GCLogger::writeLogLine(TMemoryManagerEvent event){
+    m_logFile << event.begin.toString(SNONE, 3)
+              << ": [" << event.eventName << " ";
+    if(!event.heapInfo.empty()){
+        TMemoryManagerHeapInfo eh = event.heapInfo;
+        m_logFile << eh.usedHeapSizeBeforeCollect / bytes_in_kb << "K->"
+                  << eh.usedHeapSizeAfterCollect / bytes_in_kb << "K("
+                  << eh.totalHeapSize / bytes_in_kb << "K)";
+        for(std::list<TMemoryManagerHeapEvent>::iterator i = eh.heapEvents.begin(); i != eh.heapEvents.end(); i++){
+            m_logFile << "[" << i->eventName << ": "
+                      << i->usedHeapSizeBeforeCollect / bytes_in_kb << "K->"
+                      << i->usedHeapSizeAfterCollect / bytes_in_kb << "K("
+                      << i->totalHeapSize / bytes_in_kb << "K)";
+            if(!i->timeDiff.isEmpty())
+                m_logFile << ", " << i->timeDiff.toString(SSHORT, 6);
+            m_logFile << "] ";
+        }
+    }
+    if(!event.timeDiff.isEmpty())
+        m_logFile << ", " << event.timeDiff.toString(SSHORT, 6);
+    //gc-viewer see error when no delay or delay is 0.0
+    else 
+	m_logFile << ", 0.000001 secs";
+    m_logFile << "]\n";
+}

--- a/src/GenerationalMemoryManager.cpp
+++ b/src/GenerationalMemoryManager.cpp
@@ -126,9 +126,9 @@ void GenerationalMemoryManager::collectGarbage()
     gettimeofday(&tv2, NULL);
 
     // Calculating total microseconds spent in the garbage collection procedure
-    m_totalCollectionDelay += (tv2.tv_sec - tv1.tv_sec) * 1000000 + (tv2.tv_usec - tv1.tv_usec);
+    m_memoryInfo.totalCollectionDelay += (tv2.tv_sec - tv1.tv_sec) * 1000000 + (tv2.tv_usec - tv1.tv_usec);
 
-    m_collectionsCount++;
+    m_memoryInfo.collectionsCount++;
 }
 
 void GenerationalMemoryManager::collectLeftToRight(bool fullCollect /*= false*/)

--- a/src/NonCollectMemoryManager.cpp
+++ b/src/NonCollectMemoryManager.cpp
@@ -41,12 +41,13 @@
 #include <memory.h>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
+
 
 NonCollectMemoryManager::NonCollectMemoryManager() :
-    m_heapSize(0), m_heapBase(0), m_heapPointer(0),
+    m_memoryInfo(), m_heapSize(0), m_heapBase(0), m_heapPointer(0), 
     m_staticHeapSize(0), m_staticHeapBase(0), m_staticHeapPointer(0)
-{
-}
+{}
 
 NonCollectMemoryManager::~NonCollectMemoryManager()
 {
@@ -54,6 +55,7 @@ NonCollectMemoryManager::~NonCollectMemoryManager()
     for(std::size_t i = 0; i < m_usedHeaps.size(); i++)
         free( m_usedHeaps[i] );
 }
+
 
 bool NonCollectMemoryManager::initializeStaticHeap(size_t staticHeapSize)
 {
@@ -92,6 +94,10 @@ bool NonCollectMemoryManager::initializeHeap(size_t heapSize, size_t /*maxSize*/
 
 void NonCollectMemoryManager::growHeap()
 {
+    TMemoryManagerEvent event("GC");
+    event.heapInfo.usedHeapSizeBeforeCollect = m_usedHeaps.size()*m_heapSize;
+    m_memoryInfo.collectionsCount++;
+    event.begin = m_memoryInfo.timer.get<TSec>();
     uint8_t* heap = static_cast<uint8_t*>( std::malloc(m_heapSize) );
     if (!heap) {
         std::printf("MM: Cannot allocate %zu bytes\n", m_heapSize);
@@ -104,6 +110,14 @@ void NonCollectMemoryManager::growHeap()
     m_heapPointer = heap + m_heapSize;
 
     m_usedHeaps.push_back(heap);
+
+    //there is no collecting: after = before
+    event.heapInfo.usedHeapSizeAfterCollect = event.heapInfo.usedHeapSizeBeforeCollect;
+    event.heapInfo.totalHeapSize = m_usedHeaps.size()*m_heapSize;
+    event.timeDiff = m_memoryInfo.timer.get<TSec>() - event.begin;
+    m_memoryInfo.totalCollectionDelay += event.timeDiff.convertTo<TMicrosec>().toInt();
+    m_memoryInfo.events.push_front(event);
+    m_gcLogger->writeLogLine(event);
 }
 
 void* NonCollectMemoryManager::allocate(size_t requestedSize, bool* gcOccured /*= 0*/ )
@@ -119,6 +133,8 @@ void* NonCollectMemoryManager::allocate(size_t requestedSize, bool* gcOccured /*
     }
 
     m_heapPointer -= requestedSize;
+
+    m_memoryInfo.allocationsCount++;
     return m_heapPointer;
 }
 
@@ -138,3 +154,9 @@ bool NonCollectMemoryManager::isInStaticHeap(void* location)
 {
     return (location >= m_staticHeapPointer) && (location < m_staticHeapBase + m_staticHeapSize);
 }
+
+TMemoryManagerInfo NonCollectMemoryManager::getStat() {
+    return m_memoryInfo;
+
+}
+

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,0 +1,70 @@
+
+#include "Timer.h"
+#include <math.h>
+#include <sstream>
+using std::stringstream;
+
+
+#if defined(unix) || defined(__unix__) || defined(__unix)
+Timer::Timer(time_t _time){
+    time_t current;
+    time(&current);
+    time_t diff = current - _time;
+    timeval cur_tv;
+    gettimeofday(&cur_tv, 0);
+    timeval result = {cur_tv.tv_sec - diff, 0};
+    timeCreate = result;
+}
+
+void Timer::start(){
+    gettimeofday(&timeCreate, 0);
+}
+
+double Timer::getDiffSec(){
+    timeval current;
+    gettimeofday(&current, 0);
+    double diff = current.tv_sec + current.tv_usec/static_cast<double>(TMicrosec::den)
+               - (timeCreate.tv_sec + timeCreate.tv_usec/static_cast<double>(TMicrosec::den));
+    return diff;
+}
+#else
+Timer::Timer(time_t _time){
+    time_t current;
+    time(&current);
+    clock_t diff = (current - _time)*CLOCKS_PER_SEC;
+    timeCreate = clock() - diff;
+}
+
+
+void Timer::start(){
+    timeCreate = clock();
+}
+
+double Timer::getDiffSec(){
+    return static_cast<double>((clock() - timeCreate))/CLOCKS_PER_SEC;
+}
+#endif
+
+template <> std::string TDuration<TDay>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "days" : sMode == SSHORT ? "days" : ""; }
+
+template <> std::string TDuration<THour>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "hours" : sMode == SSHORT ? "hours" : ""; }
+
+template <> std::string TDuration<TMin>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "minutes" : sMode == SSHORT ? "mins" : ""; }
+
+template <> std::string TDuration<TSec>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "seconds" : sMode == SSHORT ? "secs" : ""; }
+
+template <> std::string TDuration<TMillisec>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "milliseconds" : sMode == SSHORT ? "msecs" : ""; }
+
+template <> std::string TDuration<TMicrosec>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "microseconds" : sMode == SSHORT ? "mcsecs" : ""; }
+
+template <> std::string TDuration<TNanosec>::getSuffix(SuffixMode sMode){
+    return sMode == SFULL ? "nanoseconds" : sMode == SSHORT ? "usecs" : ""; }
+
+
+

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -46,6 +46,7 @@ void args::parse(int argc, char **argv)
         image = 'i',
         heap_max = 'H',
         heap = 'h',
+        mm_type = 'm',
 
         getopt_set_arg = 0,
         getopt_err = '?',
@@ -57,6 +58,7 @@ void args::parse(int argc, char **argv)
         {"heap_max",   required_argument, 0, heap_max},
         {"heap",       required_argument, 0, heap},
         {"image",      required_argument, 0, image},
+        {"mm_type",    required_argument, 0, mm_type},
         {"help",       no_argument,       0, help},
         {"version",    no_argument,       0, version},
         {0, 0, 0, 0}
@@ -76,6 +78,9 @@ void args::parse(int argc, char **argv)
 
             case image: {
                 imagePath = optarg;
+            } break;
+            case mm_type: {
+                memoryManagerType = optarg;
             } break;
             case heap: {
                 bool good_number = std::istringstream( optarg ) >> heapSize;


### PR DESCRIPTION
Feature completed and tested on 32-bit ubuntu (and 64-bit arch before) with and without llvm support. 

After running vm creates "gc.log" file, which format compatible with gcviewer. There is example of chart generated by command "java -jar gcviewer.jar gc.log summary.csv chart.png"

![chart](https://cloud.githubusercontent.com/assets/527307/6547043/405c2c40-c5dc-11e4-8fcc-ac392cbbe8af.png)

Issue: #47 