### PR TITLE
Fixes warnings in MethodCompiler and ControlGraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,5 @@ before_script:
 
 script:
   - ctest -M Experimental -T Start -T Build -T Test -T Submit
-
-after_script:
-  - make check --keep-going # If ctest built the project unsuccessfully, `make check` will report errors to Travis
+  - make all --keep-going && make check # If ctest built the project unsuccessfully, `make all && make check` will report errors to Travis
 

--- a/src/ControlGraph.cpp
+++ b/src/ControlGraph.cpp
@@ -97,7 +97,6 @@ private:
 
     ControlGraph*  const m_graph;
     ControlDomain* m_currentDomain;
-    bool m_skipStubInstructions;
 };
 
 InstructionNode* GraphConstructor::createNode(const TSmalltalkInstruction& instruction)
@@ -505,28 +504,6 @@ public:
                         m_nodesToRemove.push_back(instruction);
                     }
                 }
-            }
-        } else if (PhiNode* const phi = node.cast<PhiNode>()) {
-            assert(incomings.size());
-
-            // We may remove the phi node if all of it's incoming entries map to the same node
-            /*const PhiNode::TIncomingList& incomings = phi->getIncomingList();
-            const ControlNode* const testNode = incomings[0].node;
-            bool  unique = true;
-
-            for (std::size_t index = 1; index < incomings.size(); index++) {
-                if (incomings[index].node != testNode) {
-                    unique = false;
-                    break;
-                }
-            }*/
-
-            if (phi->getInEdges().size() == 1) {
-                if (traces_enabled)
-                    std::printf("GraphOptimizer::visitNode : phi node %u has only one input and may be removed\n", phi->getIndex());
-
-                // FIXME Should be modified according to new phi linking rules
-                // m_nodesToRemove.push_back(phi);
             }
         }
 

--- a/src/MethodCompiler.cpp
+++ b/src/MethodCompiler.cpp
@@ -185,7 +185,7 @@ public:
     }
 
 private:
-    st::PathVerifier& m_verifier;
+//     st::PathVerifier& m_verifier;
     bool m_detected;
 };
 

--- a/src/MethodCompiler.cpp
+++ b/src/MethodCompiler.cpp
@@ -172,7 +172,7 @@ public:
                     return st::GraphWalker::vrSkipPath;
                 } */
             }
-        } else if (st::PhiNode* const phi = node->cast<st::PhiNode>()) {
+        } else if (node->getNodeType() == st::ControlNode::ntPhi) {
             // Phi node may not cause gc, protects it's value separately
             // and do not have outgoing edges that we may traverse.
 

--- a/src/MethodCompiler.cpp
+++ b/src/MethodCompiler.cpp
@@ -140,7 +140,7 @@ Value* MethodCompiler::protectProducerNode(TJITContext& jit, st::ControlNode* no
 
 class Detector {
 public:
-    Detector(st::PathVerifier& verifier) : m_verifier(verifier), m_detected(false) {}
+    Detector() : m_detected(false) {}
 
     bool isDetected() const { return m_detected; }
 
@@ -151,26 +151,6 @@ public:
 
                 m_detected = true;
                 return st::GraphWalker::vrStopWalk;
-
-                /* / Walking through the nodes seeking for consumer
-                // If it is found then candidate node may affect
-                // the consumer. Procucer should be protected.
-                m_verifier.run(candidate);
-
-                if (m_verifier.isVerified()) {
-                    // We found a node that may cause GC and it is really
-                    // on the path between procducer and one of the consumers.
-                    // We've just proved that the value should be protected.
-
-                    m_detected = true;
-                    return st::GraphWalker::vrStopWalk;
-
-                } else {
-                    // Node may cause GC but control flow will never reach any of tracked consumers.
-                    // This means that we may safely ignore this node and all it's subpaths.
-
-                    return st::GraphWalker::vrSkipPath;
-                } */
             }
         } else if (node->getNodeType() == st::ControlNode::ntPhi) {
             // Phi node may not cause gc, protects it's value separately
@@ -185,7 +165,6 @@ public:
     }
 
 private:
-//     st::PathVerifier& m_verifier;
     bool m_detected;
 };
 
@@ -282,10 +261,7 @@ bool MethodCompiler::shouldProtectProducer(st::ControlNode* producer)
     // a complex case that affects several domains and probably phi nodes.
     // We need to perform a generic lookup walking through the whole graph.
 
-    st::PathVerifier verifier(consumers);
-    verifier.addStopNode(producer);
-
-    Detector detector(verifier);
+    Detector detector;
 
     Walker walker(detector);
     walker.addStopNode(producer);
@@ -308,16 +284,6 @@ bool MethodCompiler::shouldProtectProducer(st::ControlNode* producer)
 
 //     outs() << "Producer " << producer->getIndex() << " is safe and do not need a protection (2)\n";
     return false;
-
-    // Changing direction to forward and performing last check starting from procucer.
-    // We need to reset the stop list because now we'll use differennt edges.
-//     walker.resetStopNodes();
-//
-//     // When performing a forward run we need to end at consumers
-//     walker.addStopNodes(consumers);
-//     walker.run(producer, st::GraphWalker::wdForward);
-
-//     return detector.isDetected();
 }
 
 void MethodCompiler::writePreamble(TJITContext& jit, bool isBlock)


### PR DESCRIPTION
What changed:

- Removed unused variables
- Commented out temporarily unused `PathVerifier` in GC instruction detector
- Removed unneeded branch in `GraphOptimizer`