### PR TITLE
Provides Jit>>once: for one-time JIT execution of a block

### DIFF
--- a/image/imageSource.st
+++ b/image/imageSource.st
@@ -1551,7 +1551,12 @@ sendMessage: aSelector withArguments: anArguments
 
 METHOD MetaJit
 do: aBlock
-    self sendMessage: #value withArguments: (Array with: aBlock).
+    ^self sendMessage: #value withArguments: (Array with: aBlock).
+!
+
+METHOD MetaJit
+once: aBlock
+    <247 aBlock>
 !
 
 METHOD MetaJit

--- a/image/imageSource.st
+++ b/image/imageSource.st
@@ -1560,6 +1560,15 @@ once: aBlock
 !
 
 METHOD MetaJit
+shell | command |
+    'You have entered the JIT shell. Use Ctrl+D to exit.' printNl.
+
+    [ command <- String readline: '+>'. command notNil ]
+        whileTrue: [ command isEmpty
+            ifFalse: [ ('Jit once: [' + command + ']') doIt printNl ] ]
+!
+
+METHOD MetaJit
 printStatistics
     <248>
 !

--- a/include/jit.h
+++ b/include/jit.h
@@ -296,7 +296,10 @@ private:
     void doPushTemporary(TJITContext& jit);
     void doPushLiteral(TJITContext& jit);
     void doPushConstant(TJITContext& jit);
+
     void doPushBlock(TJITContext& jit);
+    llvm::Function* compileBlock(TJITContext& jit, const std::string& blockFunctionName, st::ParsedBlock* parsedBlock);
+
     void doAssignTemporary(TJITContext& jit);
     void doAssignInstance(TJITContext& jit);
     void doMarkArguments(TJITContext& jit);
@@ -339,6 +342,8 @@ public:
         llvm::Function* methodFunction = 0,
         llvm::Value** contextHolder = 0
     );
+
+    llvm::Function* compileBlock(TBlock* block);
 
     // TStackObject is a pair of entities allocated on a thread stack space
     // objectSlot is a container for actual object's data
@@ -407,7 +412,6 @@ private:
     TObject* sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex = 0);
 
     TBlock*  createBlock(TContext* callingContext, uint8_t argLocation, uint16_t bytePointer);
-    TObject* invokeBlock(TBlock* block, TContext* callingContext);
 
     friend TObject*     newOrdinaryObject(TClass* klass, uint32_t slotSize);
     friend TByteObject* newBinaryObject(TClass* klass, uint32_t dataSize);
@@ -507,6 +511,9 @@ private:
     void cleanupDirectHolders(llvm::IRBuilder<>& builder, TDirectBlock& directBlock);
     bool detectLiteralReceiver(llvm::Value* messageArguments);
 public:
+
+    TObject* invokeBlock(TBlock* block, TContext* callingContext, bool once = false);
+
     void patchHotMethods();
     void printMethod(TMethod* method) {
         std::string functionName = method->klass->name->toString() + ">>" + method->name->toString();

--- a/include/jit.h
+++ b/include/jit.h
@@ -437,7 +437,6 @@ private:
     static const unsigned int LOOKUP_CACHE_SIZE = 512;
     TFunctionCacheEntry      m_functionLookupCache[LOOKUP_CACHE_SIZE];
     TBlockFunctionCacheEntry m_blockFunctionLookupCache[LOOKUP_CACHE_SIZE];
-
     uint32_t m_cacheHits;
     uint32_t m_cacheMisses;
     uint32_t m_blockCacheHits;
@@ -451,6 +450,7 @@ private:
     TBlockFunction  lookupBlockFunctionInCache(TMethod* containerMethod, uint32_t blockOffset);
     void updateFunctionCache(TMethod* method, TMethodFunction function);
     void updateBlockFunctionCache(TMethod* containerMethod, uint32_t blockOffset, TBlockFunction function);
+    void flushBlockFunctionCache();
 
     void initializePassManager();
 

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -132,25 +132,25 @@ template<> hptr<TBlock> SmalltalkVM::newObject<TBlock>(std::size_t /*dataSize*/,
 
 void SmalltalkVM::TVMExecutionContext::stackPush(TObject* object)
 {
-    assert(object != 0);
+    assert(object);
+
     //NOTE: boundary check
     //      The Timothy A. Budd's version of compiler produces
     //      bytecode which can overflow the stack of the context
-    {
-        uint32_t stackSize = currentContext->stack->getSize();
-        if( stackTop >= stackSize ) {
-            //resize the current stack
-            hptr<TObjectArray> newStack = m_vm->newObject<TObjectArray>(stackSize*2);
-            std::copy(newStack->getFields(), newStack->getFields()+stackSize, currentContext->stack->getFields());
-//             for(uint32_t i = 0; i < stackSize; i++) {
-//                 TObject* value = currentContext->stack->getField(i);
-//                 newStack->putField(i, value);
-//             }
-            currentContext->stack = newStack;
-            std::cerr << currentContext->method->name->toString() << "!";
-            //std::cerr << std::endl << "VM: Stack overflow in '" << currentContext->method->name->toString() << "'" << std::endl;
-        }
+
+    TObjectArray&  oldStack  = *currentContext->stack;
+    const uint32_t stackSize = oldStack.getSize();
+
+    if (stackTop >= stackSize) {
+        hptr<TObjectArray> newStack = m_vm->newObject<TObjectArray>(stackSize + 7);
+
+        for (uint32_t i = 0; i < stackSize; i++)
+            newStack[i] = oldStack[i];
+
+        currentContext->stack = newStack;
+        std::cerr << currentContext->method->name->toString() << "!";
     }
+
     currentContext->stack->putField(stackTop++, object);
 }
 

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -758,6 +758,11 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
                 return globals.nilObject;
             }
         } break;
+
+        case 247: { // Jit once: aBlock
+            TBlock* const block = ec.stackPop<TBlock>();
+            return JITRuntime::Instance()->invokeBlock(block, ec.currentContext, true);
+        }
 #endif
 
         case 251: {

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -760,8 +760,17 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
         } break;
 
         case 247: { // Jit once: aBlock
-            TBlock* const block = ec.stackPop<TBlock>();
-            return JITRuntime::Instance()->invokeBlock(block, ec.currentContext, true);
+            try {
+                TBlock* const block = ec.stackPop<TBlock>();
+                return JITRuntime::Instance()->invokeBlock(block, ec.currentContext, true);
+            } catch(TBlockReturn& blockReturn) {
+                ec.currentContext = blockReturn.targetContext;
+                return blockReturn.value;
+            } catch(TContext* errorContext) {
+                process->context = errorContext;
+                failed = true;
+                return globals.nilObject;
+            }
         }
 #endif
 


### PR DESCRIPTION
(Desctiption was stolen from #74)

Existing `Jit>>do:` method act as a bridge between software VM implementation and the JIT.

It works well, yet once compiled, block code remains in the JIT module. Currently JIT VM does not support recompilation of an arbitrary method because a lot of run-time references need to be cleared/updated.

In case of a console method we know that compiled version of it may be thrown away right after execution. We use this fact to allow easy management of interactive JIT blocks.

`Jit>>once:` was added. It works much the same except that compiled method and it's platform code are disposed right after execution.