### PR TITLE
Fast block return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - g++-multilib
     - linux-libc-dev:i386
     - libreadline-dev:i386
-    - llvm-3.3-dev:i386
+    - llvm-3.4-dev:i386
 
 notifications:
   email: false

--- a/.travis/osx/before_install.sh
+++ b/.travis/osx/before_install.sh
@@ -9,4 +9,4 @@ function brew_upgrade { brew outdated $1 || brew upgrade $1; }
 
 brew update
 brew install readline
-brew install llvm33
+brew install llvm34

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.4)
 
 set (CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_SOURCE_DIR}/cmake/variables.cmake")
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set (LLVM_PACKAGE_VERSION 3.3)
+set (LLVM_PACKAGE_VERSION 3.4)
 
 project(llst)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,16 @@ if (USE_LLVM)
         src/llstPass.cpp
         src/llstDebuggingPass.cpp
     )
+
+    add_library(trampoline "src/trampoline.cpp")
+    set_source_files_properties(src/trampoline.cpp PROPERTIES COMPILE_FLAGS "-freg-struct-return")
 endif()
 
 add_executable(llst src/main.cpp)
 add_dependencies(llst image)
 
 if (USE_LLVM)
-    target_link_libraries(llst jit ${LLVM_LIBS} ${LLVM_LD_FLAGS})
+    target_link_libraries(llst jit trampoline ${LLVM_LIBS} ${LLVM_LD_FLAGS})
 endif()
 target_link_libraries(llst standard_set memory_managers stapi ${READLINE_LIBS_TO_LINK} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 

--- a/image/imageSource.st
+++ b/image/imageSource.st
@@ -1996,7 +1996,7 @@ run2: rounds | mock |
     self run: [ mock selfSend ] rounds: rounds text: 'Self dispatch'.
 
     self run: [ mock invokeBlock: [nil] ] rounds: rounds text: 'Block invoke'.
-    self run: [ mock blockReturn ] rounds: rounds text: 'Block return'.
+    self run: [ 1 to: rounds do: [ :x | mock blockReturn ] ] rounds: 1 text: 'Block return'.
 
     self run: [ mock selfReturn selfReturn selfReturn selfReturn selfReturn ] rounds: rounds text: 'Chain dispatch'.
     self run: [ mock selfReturn; selfReturn; selfReturn; selfReturn; selfReturn ] rounds: rounds text: 'Cascade dispatch'.
@@ -2060,6 +2060,9 @@ main    | command  data x |
     Char initialize.
     Class fillChildren.
     System fixMethodClasses.
+
+    "Jit do: [ nil runAllTests ].
+    Jit do: [ System rebuildImage ]."
 
     [ command <- String readline: '->'. command notNil ]
         whileTrue: [ command isEmpty ifFalse: [ command doIt printNl ] ]

--- a/include/Core.ll
+++ b/include/Core.ll
@@ -138,7 +138,7 @@
     %TSymbol*       ; badMethodSymbol
 }
 
-%TReturnValue = type {
+%TBlockReturn = type {
     %TObject*,      ; value
     %TContext*      ; targetContext
 }
@@ -337,13 +337,18 @@ declare %TByteObject* @newBinaryObject(%TClass*, i32)
 declare { %TObject*, %TContext* } @sendMessage(%TContext* %callingContext, %TSymbol* %selector, %TObjectArray* %arguments, %TClass* %receiverClass, i32 %callSiteOffset)
 
 declare %TBlock*  @createBlock(%TContext* %callingContext, i8 %argLocation, i16 %bytePointer)
-declare { %TObject*, %TContext* }  @invokeBlock(%TBlock* %block, %TContext* %callingContext)
+declare { %TObject*, %TContext* } @invokeBlock(%TBlock* %block, %TContext* %callingContext)
 ;declare %TObject* @invokeBlock(%TBlock* %block, %TContext* %callingContext)
 
 declare void @emitBlockReturn(%TObject* %value, %TContext* %targetContext)
 declare void @checkRoot(%TObject* %value, %TObject** %slot)
 declare i1 @bulkReplace(%TObject* %destination, %TObject* %sourceStartOffset, %TObject* %source, %TObject* %destinationStopOffset, %TObject* %destinationStartOffset)
 declare %TObject* @callPrimitive(i8 %opcode, %TObjectArray* %args, i1* %primitiveFailed)
+
+%TReturnValue = type {
+    %TObject*,      ; value
+    %TContext*      ; targetContext
+}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; exception API ;;;;;;;;;;;;;;;;;;;;;;;
@@ -355,3 +360,24 @@ declare i8* @__cxa_begin_catch(i8*)
 declare void @__cxa_end_catch()
 declare i8* @__cxa_allocate_exception(i32)
 declare void @__cxa_throw(i8*, i8*, i8*)
+
+
+define { i32, i32 } @"test2"(%TContext* %contextParameter) #1 {
+  %1 = insertvalue { i32, i32 } undef, i32 1, 0
+  %2 = insertvalue { i32, i32 } %1, i32 2, 1
+  ret { i32, i32 } %2
+}
+
+; Function Attrs: inlinehint
+define { %TObject*, %TContext* } @"Mock>>selfReturn_"(%TContext* %pContext) #1 {
+preamble:
+  %0 = getelementptr inbounds %TContext* %pContext, i32 0, i32 2
+  %1 = load %TObjectArray** %0
+  %2 = getelementptr inbounds %TObjectArray* %1, i32 0, i32 0
+  %fields.i.i = getelementptr inbounds %TObject* %2, i32 0, i32 2
+  %fieldPtr.i.i = getelementptr inbounds [0 x %TObject*]* %fields.i.i, i32 0, i32 0
+  %result.i = load %TObject** %fieldPtr.i.i
+  %3 = insertvalue { %TObject*, %TContext* } undef, %TObject* %result.i, 0
+  %4 = insertvalue { %TObject*, %TContext* } %3, %TContext* null, 1
+  ret { %TObject*, %TContext* } %4
+}

--- a/include/Core.ll
+++ b/include/Core.ll
@@ -138,7 +138,7 @@
     %TSymbol*       ; badMethodSymbol
 }
 
-%TBlockReturn = type {
+%TReturnValue = type {
     %TObject*,      ; value
     %TContext*      ; targetContext
 }
@@ -333,9 +333,13 @@ declare %TByteObject* @newBinaryObject(%TClass*, i32)
 ;;;;;;;;;;;;;;;;; runtime API ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-declare %TObject* @sendMessage(%TContext* %callingContext, %TSymbol* %selector, %TObjectArray* %arguments, %TClass* %receiverClass, i32 %callSiteOffset)
+;declare %TObject* @sendMessage(%TContext* %callingContext, %TSymbol* %selector, %TObjectArray* %arguments, %TClass* %receiverClass, i32 %callSiteOffset)
+declare { %TObject*, %TContext* } @sendMessage(%TContext* %callingContext, %TSymbol* %selector, %TObjectArray* %arguments, %TClass* %receiverClass, i32 %callSiteOffset)
+
 declare %TBlock*  @createBlock(%TContext* %callingContext, i8 %argLocation, i16 %bytePointer)
-declare %TObject* @invokeBlock(%TBlock* %block, %TContext* %callingContext)
+declare { %TObject*, %TContext* }  @invokeBlock(%TBlock* %block, %TContext* %callingContext)
+;declare %TObject* @invokeBlock(%TBlock* %block, %TContext* %callingContext)
+
 declare void @emitBlockReturn(%TObject* %value, %TContext* %targetContext)
 declare void @checkRoot(%TObject* %value, %TObject** %slot)
 declare i1 @bulkReplace(%TObject* %destination, %TObject* %sourceStartOffset, %TObject* %source, %TObject* %destinationStopOffset, %TObject* %destinationStartOffset)
@@ -346,6 +350,7 @@ declare %TObject* @callPrimitive(i8 %opcode, %TObjectArray* %args, i1* %primitiv
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 declare i32 @__gcc_personality_v0(...)
+declare i32 @__gxx_personality_v0(...)
 declare i8* @__cxa_begin_catch(i8*)
 declare void @__cxa_end_catch()
 declare i8* @__cxa_allocate_exception(i32)

--- a/include/jit.h
+++ b/include/jit.h
@@ -90,7 +90,7 @@ struct TObjectTypes {
     llvm::StructType* byteObject;
     llvm::StructType* blockReturn;
     llvm::StructType* process;
-
+    llvm::StructType* returnValueType;
 
     void initializeFromModule(llvm::Module* module) {
         object      = module->getTypeByName("TObject");
@@ -104,8 +104,14 @@ struct TObjectTypes {
         symbolArray = module->getTypeByName("TSymbolArray");
         globals     = module->getTypeByName("TGlobals");
         byteObject  = module->getTypeByName("TByteObject");
-        blockReturn = module->getTypeByName("TBlockReturn");
+        blockReturn = module->getTypeByName("TReturnValue");
         process     = module->getTypeByName("TProcess");
+
+        returnValueType = llvm::StructType::get(
+            object->getPointerTo(),
+            context->getPointerTo(),
+            NULL
+        );
     }
 };
 
@@ -206,6 +212,9 @@ public:
 
         llvm::BasicBlock*   preamble;
         llvm::BasicBlock*   exceptionLandingPad;
+        llvm::BasicBlock*   unwindBlockReturn;
+        llvm::PHINode*      unwindPhi;
+
         bool                methodHasBlockReturn;
         bool                methodAllocatesMemory;
 
@@ -221,7 +230,7 @@ public:
 
         TJITContext(MethodCompiler* compiler, TMethod* method, bool parse = true)
         : currentNode(0), originMethod(method), function(0), builder(0),
-            preamble(0), exceptionLandingPad(0), methodHasBlockReturn(false),
+            preamble(0), exceptionLandingPad(0), unwindBlockReturn(0), unwindPhi(0), methodHasBlockReturn(false),
             methodAllocatesMemory(true), compiler(compiler), contextHolder(0), selfHolder(0)
         {
             if (parse) {
@@ -289,6 +298,8 @@ private:
     void writeFunctionBody(TJITContext& jit);
     void writeInstruction(TJITContext& jit);
     void writeLandingPad(TJITContext& jit);
+    void writeUnwindBlockReturn(TJITContext& jit);
+    void emitReturn(TJITContext& jit, llvm::Value* object, llvm::Value* targetContext = 0);
 
     void doPushInstance(TJITContext& jit);
     void doPushArgument(TJITContext& jit);
@@ -370,12 +381,24 @@ public:
     }
 };
 
+
+struct TReturnValue {
+    TObject*  value;
+    TContext* targetContext;
+    TReturnValue(TObject* value, TContext* targetContext)
+    : value(value), targetContext(targetContext) { }
+
+    static void* getBlockReturnType() {
+        return const_cast<void*>(reinterpret_cast<const void*>( &typeid(TReturnValue) ));
+    }
+};
+
 extern "C" {
     TObject*     newOrdinaryObject(TClass* klass, uint32_t slotSize);
     TByteObject* newBinaryObject(TClass* klass, uint32_t dataSize);
-    TObject*     sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex);
+    TReturnValue sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex);
     TBlock*      createBlock(TContext* callingContext, uint8_t argLocation, uint16_t bytePointer);
-    TObject*     invokeBlock(TBlock* block, TContext* callingContext);
+    TReturnValue invokeBlock(TBlock* block, TContext* callingContext);
     void         emitBlockReturn(TObject* value, TContext* targetContext);
     const void*  getBlockReturnType();
     void         checkRoot(TObject* value, TObject** objectSlot);
@@ -389,8 +412,8 @@ extern "C" {
 
 class JITRuntime {
 public:
-    typedef TObject* (*TMethodFunction)(TContext*);
-    typedef TObject* (*TBlockFunction)(TBlock*);
+    typedef TReturnValue (*TMethodFunction)(TContext*);
+    typedef TReturnValue (*TBlockFunction)(TBlock*);
 
 private:
     llvm::FunctionPassManager* m_functionPassManager;
@@ -408,15 +431,16 @@ private:
 
     static JITRuntime* s_instance;
 
-    TObject* sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex = 0);
+    TReturnValue sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex = 0);
 
     TBlock*  createBlock(TContext* callingContext, uint8_t argLocation, uint16_t bytePointer);
+    TReturnValue invokeBlock(TBlock* block, TContext* callingContext);
 
     friend TObject*     newOrdinaryObject(TClass* klass, uint32_t slotSize);
     friend TByteObject* newBinaryObject(TClass* klass, uint32_t dataSize);
-    friend TObject*     sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex);
+    friend TReturnValue sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex);
     friend TBlock*      createBlock(TContext* callingContext, uint8_t argLocation, uint16_t bytePointer);
-    friend TObject*     invokeBlock(TBlock* block, TContext* callingContext);
+    friend TReturnValue invokeBlock(TBlock* block, TContext* callingContext);
     friend void         emitBlockReturn(TObject* value, TContext* targetContext);
 
     struct TFunctionCacheEntry
@@ -537,13 +561,3 @@ public:
     ~JITRuntime();
 };
 
-struct TBlockReturn {
-    TObject*  value;
-    TContext* targetContext;
-    TBlockReturn(TObject* value, TContext* targetContext)
-        : value(value), targetContext(targetContext) { }
-
-    static void* getBlockReturnType() {
-        return const_cast<void*>(reinterpret_cast<const void*>( &typeid(TBlockReturn) ));
-    }
-};

--- a/src/JITRuntime.cpp
+++ b/src/JITRuntime.cpp
@@ -153,10 +153,10 @@ void JITRuntime::initialize(SmalltalkVM* softVM)
     // These are then used as an allocator function return types
 
     TargetOptions Opts;
-    Opts.JITExceptionHandling = true;
+//    Opts.JITExceptionHandling = true;
     Opts.GuaranteedTailCallOpt = true;
 //    Opts.JITEmitDebugInfo = true;
-//     Opts.PrintMachineCode = true;
+//    Opts.PrintMachineCode = true;
 
     std::string error;
     m_executionEngine = EngineBuilder(m_JITModule)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char **argv) {
     std::auto_ptr<Image> smalltalkImage(new Image(memoryManager.get()));
     smalltalkImage->loadImage(llstArgs.imagePath);
 
+
     SmalltalkVM vm(smalltalkImage.get(), memoryManager.get());
 
     // Creating completion database and filling it with info
@@ -103,6 +104,8 @@ int main(int argc, char **argv) {
     JITRuntime runtime;
     runtime.initialize(&vm);
 #endif
+
+//     testCompiler(smalltalkImage.get(), runtime);
 
     // Creating runtime context
     hptr<TContext> initContext = vm.newObject<TContext>();

--- a/src/trampoline.cpp
+++ b/src/trampoline.cpp
@@ -1,0 +1,29 @@
+#include <jit.h>
+
+extern "C" {
+
+void methodTrampoline(JITRuntime::TMethodFunction function, TContext* context, TReturnValue& result)
+{
+    result = function(context);
+}
+
+void blockTrampoline(JITRuntime::TBlockFunction function, TBlock* block, TReturnValue& result)
+{
+    result = function(block);
+}
+
+TReturnValue sendMessage(TContext* callingContext, TSymbol* message, TObjectArray* arguments, TClass* receiverClass, uint32_t callSiteIndex)
+{
+    TReturnValue result;
+    JITRuntime::Instance()->sendMessage(callingContext, message, arguments, receiverClass, callSiteIndex, result);
+    return result;
+}
+
+TReturnValue invokeBlock(TBlock* block, TContext* callingContext)
+{
+    TReturnValue result;
+    JITRuntime::Instance()->invokeBlock(block, callingContext, result, false);
+    return result;
+}
+
+}

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -53,9 +53,9 @@ TObject* SmalltalkVM::newOrdinaryObject(TClass* klass, std::size_t slotSize)
     // so we need to protect the pointer
     hptr<TClass> pClass = newPointer(klass);
 
-    void* objectSlot = m_memoryManager->allocate(correctPadding(slotSize), &m_lastGCOccured);
+    void* const objectSlot = m_memoryManager->allocate(correctPadding(slotSize), &m_lastGCOccured);
     if (!objectSlot) {
-        std::fprintf(stderr, "VM: memory manager failed to allocate %u bytes\n", slotSize);
+        std::fprintf(stderr, "VM: memory manager failed to allocate %zu bytes\n", slotSize);
         return globals.nilObject;
     }
 
@@ -68,7 +68,7 @@ TObject* SmalltalkVM::newOrdinaryObject(TClass* klass, std::size_t slotSize)
     // number of pointers except for the first two fields
     std::size_t fieldsCount = slotSize / sizeof(TObject*) - 2;
 
-    TObject* instance = new (objectSlot) TObject(fieldsCount, pClass);
+    TObject* const instance = new (objectSlot) TObject(fieldsCount, pClass);
 
     for (uint32_t index = 0; index < fieldsCount; index++)
         instance->putField(index, globals.nilObject);
@@ -86,7 +86,7 @@ TByteObject* SmalltalkVM::newBinaryObject(TClass* klass, std::size_t dataSize)
     // They could not have ordinary fields, so we may use it
     uint32_t slotSize = sizeof(TByteObject) + dataSize;
 
-    void* objectSlot = m_memoryManager->allocate(correctPadding(slotSize), &m_lastGCOccured);
+    void* const objectSlot = m_memoryManager->allocate(correctPadding(slotSize), &m_lastGCOccured);
     if (!objectSlot) {
         std::fprintf(stderr, "VM: memory manager failed to allocate %d bytes\n", slotSize);
         return static_cast<TByteObject*>(globals.nilObject);
@@ -97,36 +97,36 @@ TByteObject* SmalltalkVM::newBinaryObject(TClass* klass, std::size_t dataSize)
     if (m_lastGCOccured)
         onCollectionOccured();
 
-    TByteObject* instance = new (objectSlot) TByteObject(dataSize, pClass);
+    TByteObject* const instance = new (objectSlot) TByteObject(dataSize, pClass);
 
     return instance;
 }
 
 template<> hptr<TObjectArray> SmalltalkVM::newObject<TObjectArray>(std::size_t dataSize, bool registerPointer)
 {
-    TClass* klass = globals.arrayClass;
-    TObjectArray* instance = static_cast<TObjectArray*>( newOrdinaryObject(klass, sizeof(TObjectArray) + dataSize * sizeof(TObject*)) );
+    TClass* const klass = globals.arrayClass;
+    TObjectArray* const instance = static_cast<TObjectArray*>( newOrdinaryObject(klass, sizeof(TObjectArray) + dataSize * sizeof(TObject*)) );
     return hptr<TObjectArray>(instance, m_memoryManager, registerPointer);
 }
 
 template<> hptr<TSymbolArray> SmalltalkVM::newObject<TSymbolArray>(std::size_t dataSize, bool registerPointer)
 {
-    TClass* klass = globals.arrayClass;
-    TSymbolArray* instance = static_cast<TSymbolArray*>( newOrdinaryObject(klass, sizeof(TSymbolArray) + dataSize * sizeof(TObject*)) );
+    TClass* const klass = globals.arrayClass;
+    TSymbolArray* const instance = static_cast<TSymbolArray*>( newOrdinaryObject(klass, sizeof(TSymbolArray) + dataSize * sizeof(TObject*)) );
     return hptr<TSymbolArray>(instance, m_memoryManager, registerPointer);
 }
 
 template<> hptr<TContext> SmalltalkVM::newObject<TContext>(std::size_t /*dataSize*/, bool registerPointer)
 {
-    TClass* klass = globals.contextClass;
-    TContext* instance = static_cast<TContext*>( newOrdinaryObject(klass, sizeof(TContext)) );
+    TClass* const klass = globals.contextClass;
+    TContext* const instance = static_cast<TContext*>( newOrdinaryObject(klass, sizeof(TContext)) );
     return hptr<TContext>(instance, m_memoryManager, registerPointer);
 }
 
 template<> hptr<TBlock> SmalltalkVM::newObject<TBlock>(std::size_t /*dataSize*/, bool registerPointer)
 {
-    TClass* klass = globals.blockClass;
-    TBlock* instance = static_cast<TBlock*>( newOrdinaryObject(klass, sizeof(TBlock)) );
+    TClass* const klass = globals.blockClass;
+    TBlock* const instance = static_cast<TBlock*>( newOrdinaryObject(klass, sizeof(TBlock)) );
     return hptr<TBlock>(instance, m_memoryManager, registerPointer);
 }
 
@@ -269,8 +269,8 @@ SmalltalkVM::TExecuteResult SmalltalkVM::execute(TProcess* p, uint32_t ticks)
 
             case opcode::assignTemporary: temporaries[ec.instruction.getArgument()] = ec.stackLast();    break;
             case opcode::assignInstance: {
-                TObject*  newValue   =   ec.stackLast();
-                TObject** objectSlot = & instanceVariables[ec.instruction.getArgument()];
+                TObject*  const newValue   =   ec.stackLast();
+                TObject** const objectSlot = & instanceVariables[ec.instruction.getArgument()];
 
                 // Checking whether we need to register current object slot in the GC
                 checkRoot(newValue, objectSlot);
@@ -325,8 +325,8 @@ void SmalltalkVM::doPushBlock(TVMExecutionContext& ec)
     hptr<TBlock> newBlock = newObject<TBlock>();
 
     // Allocating block's stack
-    const uint32_t stackSize = ec.currentContext->method->stackSize;
-    newBlock->stack    = newObject<TObjectArray>(stackSize/*, false*/);
+    const uint32_t stackSize   = ec.currentContext->method->stackSize;
+    newBlock->stack            = newObject<TObjectArray>(stackSize/*, false*/);
 
     newBlock->argumentLocation = ec.instruction.getArgument();
     newBlock->blockBytePointer = ec.bytePointer;
@@ -353,7 +353,7 @@ void SmalltalkVM::doPushBlock(TVMExecutionContext& ec)
 
 void SmalltalkVM::doMarkArguments(TVMExecutionContext& ec)
 {
-    hptr<TObjectArray> args  = newObject<TObjectArray>(ec.instruction.getArgument());
+    hptr<TObjectArray> args = newObject<TObjectArray>(ec.instruction.getArgument());
 
     // This operation takes specified amount of arguments
     // from top of the stack and creates new array with them
@@ -370,7 +370,7 @@ void SmalltalkVM::doSendMessage(TVMExecutionContext& ec, TSymbol* selector, TObj
     hptr<TObjectArray> messageArguments = newPointer(arguments);
 
     if (!receiverClass) {
-        TObject* receiver = messageArguments[0];
+        TObject* const receiver = messageArguments[0];
         assert(receiver != 0);
         receiverClass = isSmallInteger(receiver) ? globals.smallIntClass : receiver->getClass();
         assert(receiverClass != 0);
@@ -456,18 +456,18 @@ void SmalltalkVM::setupVarsForDoesNotUnderstand(hptr<TMethod>& method, hptr<TObj
 
 void SmalltalkVM::doSendMessage(TVMExecutionContext& ec)
 {
-    TObjectArray* messageArguments = ec.stackPop<TObjectArray>();
+    TObjectArray* const messageArguments = ec.stackPop<TObjectArray>();
 
     // These do not need to be hptr'ed
-    TSymbolArray& literals   = * ec.currentContext->method->literals;
-    TSymbol* messageSelector = literals[ec.instruction.getArgument()];
+    TSymbolArray& literals = * ec.currentContext->method->literals;
+    TSymbol* const messageSelector = literals[ec.instruction.getArgument()];
 
     doSendMessage(ec, messageSelector, messageArguments);
 }
 
 void SmalltalkVM::doSendUnary(TVMExecutionContext& ec)
 {
-    TObject* top = ec.stackPop();
+    TObject* const top = ec.stackPop();
 
     switch ( static_cast<unaryBuiltIns::Opcode>(ec.instruction.getArgument()) ) {
         case unaryBuiltIns::isNil  : ec.returnedValue = (top == globals.nilObject) ? globals.trueObject : globals.falseObject; break;
@@ -486,8 +486,8 @@ void SmalltalkVM::doSendUnary(TVMExecutionContext& ec)
 void SmalltalkVM::doSendBinary(TVMExecutionContext& ec)
 {
     // Loading the operand objects
-    TObject* rightObject = ec.stackPop();
-    TObject* leftObject  = ec.stackPop();
+    TObject* const rightObject = ec.stackPop();
+    TObject* const leftObject  = ec.stackPop();
 
     // If operands are both small integers, we may handle it ourselves
     if (isSmallInteger(leftObject) && isSmallInteger(rightObject)) {
@@ -529,15 +529,15 @@ void SmalltalkVM::doSendBinary(TVMExecutionContext& ec)
         messageArguments[1] = pRightObject;
         messageArguments[0] = pLeftObject;
 
-        TSymbol* messageSelector = static_cast<TSymbol*>( globals.binaryMessages[ec.instruction.getArgument()] );
+        TSymbol* const messageSelector = static_cast<TSymbol*>( globals.binaryMessages[ec.instruction.getArgument()] );
         doSendMessage(ec, messageSelector, messageArguments);
     }
 }
 
 SmalltalkVM::TExecuteResult SmalltalkVM::doSpecial(hptr<TProcess>& process, TVMExecutionContext& ec)
 {
-    TObjectArray& arguments  = * ec.currentContext->arguments;
-    TSymbolArray& literals   = * ec.currentContext->method->literals;
+    TObjectArray& arguments = * ec.currentContext->arguments;
+    TSymbolArray& literals  = * ec.currentContext->method->literals;
 
     switch(ec.instruction.getArgument())
     {
@@ -571,7 +571,7 @@ SmalltalkVM::TExecuteResult SmalltalkVM::doSpecial(hptr<TProcess>& process, TVME
 
         case special::blockReturn: {
             ec.returnedValue = ec.stackPop();
-            TBlock* contextAsBlock = ec.currentContext.cast<TBlock>();
+            TBlock* const contextAsBlock = ec.currentContext.cast<TBlock>();
             ec.currentContext = contextAsBlock->creatingContext->previousContext;
 
             if (ec.currentContext.rawptr() == globals.nilObject) {
@@ -614,8 +614,8 @@ SmalltalkVM::TExecuteResult SmalltalkVM::doSpecial(hptr<TProcess>& process, TVME
 
         case special::sendToSuper: {
             uint32_t literalIndex    = ec.instruction.getExtra();
-            TSymbol* messageSelector = literals[literalIndex];
-            TClass*  receiverClass   = ec.currentContext->method->klass->parentClass;
+            TSymbol* const messageSelector = literals[literalIndex];
+            TClass*  const receiverClass   = ec.currentContext->method->klass->parentClass;
             TObjectArray* messageArguments = ec.stackPop<TObjectArray>();
 
             doSendMessage(ec, messageSelector, messageArguments, receiverClass);
@@ -739,8 +739,8 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
 
 #if defined(LLVM)
         case primitive::LLVMsendMessage: { //252
-            TObjectArray* args = ec.stackPop<TObjectArray>();
-            TSymbol*  selector = ec.stackPop<TSymbol>();
+            TObjectArray* const args = ec.stackPop<TObjectArray>();
+            TSymbol*  const selector = ec.stackPop<TSymbol>();
             try {
                 TReturnValue returnValue;
                 JITRuntime::Instance()->sendMessage(ec.currentContext, selector, args, 0, 0, returnValue);
@@ -789,7 +789,7 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
         case 251: {
             // TODO Unicode support
 
-            TString* prompt = ec.stackPop<TString>();
+            TString* const prompt = ec.stackPop<TString>();
             std::string strPrompt(reinterpret_cast<const char*>(prompt->getBytes()), prompt->getSize());
 
             std::string input;
@@ -799,7 +799,7 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
                 if ( !input.empty() )
                     CompletionEngine::Instance()->addHistory(input);
 
-                TString* result = static_cast<TString*>( newBinaryObject(globals.stringClass, input.size()) );
+                TString* const result = static_cast<TString*>( newBinaryObject(globals.stringClass, input.size()) );
                 std::memcpy(result->getBytes(), input.c_str(), input.size());
                 return result;
             } else
@@ -822,8 +822,8 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
 #endif
 
         case primitive::startNewProcess: { // 6
-            TInteger  ticks = ec.stackPop();
-            TProcess* newProcess = ec.stackPop<TProcess>();
+            TInteger ticks = ec.stackPop();
+            TProcess* const newProcess = ec.stackPop<TProcess>();
 
             // FIXME possible stack overflow due to recursive call
             TExecuteResult result = this->execute(newProcess, ticks);
@@ -833,8 +833,8 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
 
         case primitive::allocateObject: { // 7
             // Taking object's size and class from the stack
-            TObject* size  = ec.stackPop();
-            TClass*  klass = ec.stackPop<TClass>();
+            TObject* const size  = ec.stackPop();
+            TClass*  const klass = ec.stackPop<TClass>();
             uint32_t fieldsCount = TInteger(size);
 
             // Instantinating the object. Each object has size and class fields
@@ -843,14 +843,14 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
         } break;
 
         case primitive::blockInvoke: { // 8
-            TBlock*  block = ec.stackPop<TBlock>();
+            TBlock*  const block = ec.stackPop<TBlock>();
             uint32_t argumentLocation = block->argumentLocation;
 
             // Amount of arguments stored on the stack except the block itself
             uint32_t argCount = ec.instruction.getArgument() - 1;
 
             // Checking the passed temps size
-            TObjectArray* blockTemps = block->temporaries;
+            TObjectArray* const blockTemps = block->temporaries;
 
             if (argCount > (blockTemps ? blockTemps->getSize() - argumentLocation : 0) ) {
                 ec.stackTop -= (argCount  + 1); // unrolling stack
@@ -888,8 +888,9 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
 
         case primitive::arrayAt:      // 24
         case primitive::arrayAtPut: { // 5
-            TObject* indexObject = ec.stackPop();
-            TObjectArray* array  = ec.stackPop<TObjectArray>();
+            TObject* const indexObject = ec.stackPop();
+            TObjectArray* const array  = ec.stackPop<TObjectArray>();
+
             TObject* valueObject = 0;
 
             // If the method is Array:at:put then pop a value from the stack
@@ -916,7 +917,7 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
             } else {
                 // Array:at:put
 
-                TObject** objectSlot = &( array->getFields()[actualIndex] );
+                TObject** const objectSlot = &( array->getFields()[actualIndex] );
 
                 // Checking whether we need to register current object slot in the GC
                 checkRoot(valueObject, objectSlot);
@@ -930,12 +931,12 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
         } break;
 
         case primitive::cloneByteObject: { // 23
-            TClass* klass = ec.stackPop<TClass>();
+            TClass* const klass = ec.stackPop<TClass>();
             hptr<TByteObject> original = newPointer( ec.stackPop<TByteObject>() );
 
             // Creating clone
-            uint32_t dataSize  = original->getSize();
-            TByteObject* clone = newBinaryObject(klass, dataSize);
+            uint32_t dataSize = original->getSize();
+            TByteObject* const clone = newBinaryObject(klass, dataSize);
 
             // Cloning data
             std::memcpy(clone->getBytes(), original->getBytes(), dataSize);
@@ -953,7 +954,7 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
         //             break;
 
         case primitive::integerNew: { // 32
-            TObject* object = ec.stackPop();
+            TObject* const object = ec.stackPop();
             if (! isSmallInteger(object)) {
                 failed = true;
                 break;
@@ -979,11 +980,11 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
             //      stop
             //      start
 
-            TObject* destination            = ec.stackPop();
-            TObject* sourceStartOffset      = ec.stackPop();
-            TObject* source                 = ec.stackPop();
-            TObject* destinationStopOffset  = ec.stackPop();
-            TObject* destinationStartOffset = ec.stackPop();
+            TObject* const destination            = ec.stackPop();
+            TObject* const sourceStartOffset      = ec.stackPop();
+            TObject* const source                 = ec.stackPop();
+            TObject* const destinationStopOffset  = ec.stackPop();
+            TObject* const destinationStartOffset = ec.stackPop();
 
             bool isSucceeded = doBulkReplace( destination, destinationStartOffset, destinationStopOffset, source, sourceStartOffset );
 
@@ -1034,7 +1035,7 @@ TObject* SmalltalkVM::performPrimitive(uint8_t opcode, hptr<TProcess>& process, 
             while (i > 0)
                 args[--i] = ec.stackPop();
 
-            TObject* result = callPrimitive(opcode, args, failed);
+            TObject* const result = callPrimitive(opcode, args, failed);
             return result;
         }
     }
@@ -1081,8 +1082,8 @@ bool SmalltalkVM::doBulkReplace( TObject* destination, TObject* destinationStart
 
     if ( source->isBinary() && destination->isBinary() ) {
         // Interpreting pointer array as raw byte sequence
-        uint8_t* sourceBytes      = static_cast<TByteObject*>(source)->getBytes();
-        uint8_t* destinationBytes = static_cast<TByteObject*>(destination)->getBytes();
+        uint8_t* const sourceBytes      = static_cast<TByteObject*>(source)->getBytes();
+        uint8_t* const destinationBytes = static_cast<TByteObject*>(destination)->getBytes();
 
         // Primitive may be called on the same object, so memory overlapping may occur.
         // memmove() works much like the ordinary memcpy() except that it correctly
@@ -1099,8 +1100,8 @@ bool SmalltalkVM::doBulkReplace( TObject* destination, TObject* destinationStart
     }
 
     if ( ! source->isBinary() && ! destination->isBinary() ) {
-        TObject** sourceFields      = source->getFields();
-        TObject** destinationFields = destination->getFields();
+        TObject** const sourceFields      = source->getFields();
+        TObject** const destinationFields = destination->getFields();
 
         // Primitive may be called on the same object, so memory overlapping may occur.
         // memmove() works much like the ordinary memcpy() except that it correctly


### PR DESCRIPTION
Original implementation uses exception API to perform far jump to dispatch `BlockReturn` instruction. This work OK but is terribly slow. I mean REALLY slow, 10 times slower than the software implementation and 40 times slower than implementation proposed here.

Current pull request implements `BlockReturn` using MRV technique to return several values in registers instead of stack. In our case result object is returned in `eax` whereas target context in `edx` (on x86 of course). Cascade block return is handled by simply propagating these two registers unchanged from inner stack frame to outer and so on. Typical overhead is one `cmp` or `test` instruction per message send and one `ret` instruction per frame.

We use use [`-freg-struct-return`](https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html) technique which is uncommon in UNIX world and it's calling conventions, but is fully supported in GCC and clang depending on a compiler version.

More portable implementation should pass return value using the stack ([`sret`](http://llvm.org/docs/LangRef.html#parameter-attributes) in terms of LLVM) but this will be slower and will not handle cascade return in a straightforward way.
